### PR TITLE
add javascript based config file 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,12 @@ RUN npm run build
 
 # production environment
 FROM nginx:1.13.9-alpine
-RUN rm -rf /etc/nginx/conf.d 
-RUN mkdir /etc/nginx/conf.d
+ENV REACT_APP_BACKEND_URL "http://localhost:8081/apis/rest"
+RUN rm -rf /etc/nginx/conf.d && \
+  mkdir /etc/nginx/conf.d 
+COPY scripts/startup.sh /opt/
 COPY docker/default.conf /etc/nginx/conf.d
 COPY --from=builder /usr/src/app/build /usr/share/nginx/html/
+RUN chmod a+x /opt/startup.sh 
 EXPOSE 8080
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["/opt/startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN mkdir /usr/src/app
 WORKDIR /usr/src/app
 ENV PATH /usr/src/app/node_modules/.bin:$PATH
 COPY package.json /usr/src/app/
-RUN npm install
-RUN npm install react-scripts@2.1.3 -g
+RUN npm install && \
+  npm install react-scripts@2.1.3 -g
 COPY . /usr/src/app
 ENV REACT_APP_BACKEND "http://localhost:8081/apis/rest"
 ENV PUBLIC_URL "/"

--- a/README.md
+++ b/README.md
@@ -20,8 +20,21 @@ PUBLIC_URL - By default EAM Light Frontend should be hosted at the web server's 
 
 REACT_APP_LOGIN_METHOD - Change this parameter if you would like to disable the standard login prompt window and secure EAM Light with shared authentication schema of your enterprise. This requires further configuration of EAM Light Backend (explained on the project's website).
 
-## Run
+### Back-end URL 
 
+The back-end URL for the front-end application is set when the application server starts. 
+There is a configuration javascript file (public/environmentConfig.js) this file is imported into the main index.html.
+
+The images starts with a custom startup script (scripts/startup.sh) which will first actualize this configuration from the environment variables (vis envsubst) and then start nginx as a foreground process.
+
+The back-end url from the imported configuration script can be used/referenced like this : "window.environment.REACT_APP_BACKEND_URL". 
+
+Parts:
+- window: This object is supported by all browsers. It represents the browser's [window](https://www.w3schools.com/js/js_window.asp). 
+- environment: This is the custom object where we are going to store the configuration values. This object can have functions and attributes.
+- REACT_APP_BACKEND_URL: This is the attribute which contains the value which we want to use as a reference.
+
+## Run
 
 For the moment you have to manually build the docker image. Once you have your own environment variables set up, please execute the following sequence of commands to build and start the docker container:
 ```

--- a/public/environmentConfig.js
+++ b/public/environmentConfig.js
@@ -1,0 +1,3 @@
+var environment = {
+   REACT_APP_BACKEND_URL: "$REACT_APP_BACKEND_URL"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>EAM Light</title>
+    <script type="text/javascript" src="environmentConfig.js"></script>
   </head>
   <body>
     <noscript>

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+mv /usr/share/nginx/html/environmentConfig.js /opt/environmentConfig.js
+envsubst < /opt/environmentConfig.js >> /usr/share/nginx/html/environmentConfig.js 
+nginx -g 'daemon off;'

--- a/src/tools/WS.js
+++ b/src/tools/WS.js
@@ -50,11 +50,11 @@ class WS {
 
     getSearchData(keyword, config = {}) {
         keyword = encodeURIComponent(keyword);
-        return ajax.get(process.env.REACT_APP_BACKEND + '/index?s=' + keyword, config);
+        return ajax.get(window.environment.REACT_APP_BACKEND_URL + '/index?s=' + keyword, config);
     }
 
     getSearchSingleResult(keyword, config = {}) {
-        return ajax.get(process.env.REACT_APP_BACKEND + '/index/singleresult?s=' + keyword, config);
+        return ajax.get(window.environment.REACT_APP_BACKEND_URL + '/index/singleresult?s=' + keyword, config);
     }
 
     //
@@ -84,19 +84,19 @@ class WS {
     //
     //
     _get(url, config = {}) {
-        return ajax.get(process.env.REACT_APP_BACKEND + url, config);
+        return ajax.get(window.environment.REACT_APP_BACKEND_URL + url, config);
     }
 
     _post(url, data, config = {}) {
-        return ajax.post(process.env.REACT_APP_BACKEND + url, data, config);
+        return ajax.post(window.environment.REACT_APP_BACKEND_URL + url, data, config);
     }
 
     _put(url, data, config = {}) {
-        return ajax.put(process.env.REACT_APP_BACKEND + url, data, config);
+        return ajax.put(window.environment.REACT_APP_BACKEND_URL + url, data, config);
     }
 
     _delete(url, config = {}) {
-        return ajax.delete(process.env.REACT_APP_BACKEND + url, config);
+        return ajax.delete(window.environment.REACT_APP_BACKEND_URL + url, config);
     }
 
 }

--- a/src/tools/WSImpact.js
+++ b/src/tools/WSImpact.js
@@ -6,49 +6,49 @@ import ajax from 'eam-components/dist/tools/ajax';
 class WSImpact {
 
     getData(config = {}) {
-        return ajax.get(process.env.REACT_APP_BACKEND.replace('/eamlightws/rest', '/cern-eam-services/rest') + `/impact/data`, config);
+        return ajax.get(window.environment.REACT_APP_BACKEND_URL.replace('/eamlightws/rest', '/cern-eam-services/rest') + `/impact/data`, config);
     }
 
     getLayoutInfo(facility, activityType, config = {}) {
         facility = encodeURIComponent(facility);
         activityType = encodeURIComponent(activityType);
-        return ajax.get(process.env.REACT_APP_BACKEND.replace('/eamlightws/rest', '/cern-eam-services/rest') + `/impact/layout/${facility}/${activityType}`, config);
+        return ajax.get(window.environment.REACT_APP_BACKEND_URL.replace('/eamlightws/rest', '/cern-eam-services/rest') + `/impact/layout/${facility}/${activityType}`, config);
     }
 
     getImpactActivity(activityId, config = {}) {
         activityId = encodeURIComponent(activityId);
-        return ajax.get(process.env.REACT_APP_BACKEND.replace('/eamlightws/rest', '/cern-eam-services/rest') + `/impact/activities/${activityId}`, config);
+        return ajax.get(window.environment.REACT_APP_BACKEND_URL.replace('/eamlightws/rest', '/cern-eam-services/rest') + `/impact/activities/${activityId}`, config);
     }
 
     getWorkorderInfo(workorderNumber, config = {}) {
         workorderNumber = encodeURIComponent(workorderNumber);
-        return ajax.get(process.env.REACT_APP_BACKEND.replace('/eamlightws/rest', '/cern-eam-services/rest') + `/impact/workorders/${workorderNumber}`, config);
+        return ajax.get(window.environment.REACT_APP_BACKEND_URL.replace('/eamlightws/rest', '/cern-eam-services/rest') + `/impact/workorders/${workorderNumber}`, config);
     }
 
     getWorkorderInfosWithSameActivity(activityId, config = {}) {
         activityId = encodeURIComponent(activityId);
-        return ajax.get(process.env.REACT_APP_BACKEND.replace('/eamlightws/rest', '/cern-eam-services/rest') + `/impact/workorderswithactivity/${activityId}`, config);
+        return ajax.get(window.environment.REACT_APP_BACKEND_URL.replace('/eamlightws/rest', '/cern-eam-services/rest') + `/impact/workorderswithactivity/${activityId}`, config);
     }
 
     getImpactFacilities(locationCode, config = {}) {
         locationCode = encodeURIComponent(locationCode);
-        return ajax.get(process.env.REACT_APP_BACKEND.replace('/eamlightws/rest', '/cern-eam-services/rest') + `/impact/location/facilities?locationCode=${locationCode}`, config);
+        return ajax.get(window.environment.REACT_APP_BACKEND_URL.replace('/eamlightws/rest', '/cern-eam-services/rest') + `/impact/location/facilities?locationCode=${locationCode}`, config);
     }
 
     createImpactActivity(impactActivity, config = {}) {
-        return ajax.post(process.env.REACT_APP_BACKEND.replace('/eamlightws/rest', '/cern-eam-services/rest') + '/impact/', impactActivity, config);
+        return ajax.post(window.environment.REACT_APP_BACKEND_URL.replace('/eamlightws/rest', '/cern-eam-services/rest') + '/impact/', impactActivity, config);
     }
 
     linkWorkorderToImpactActivity(workordernum, activityid, config = {}) {
-        return ajax.post(process.env.REACT_APP_BACKEND.replace('/eamlightws/rest', '/cern-eam-services/rest') + `/impact/workorders/${workordernum}/activities/${activityid}`, config);
+        return ajax.post(window.environment.REACT_APP_BACKEND_URL.replace('/eamlightws/rest', '/cern-eam-services/rest') + `/impact/workorders/${workordernum}/activities/${activityid}`, config);
     }
 
     linkWorkordersToImpactActivity(impactActivity, workorders, config = {}) {
-        return ajax.put(process.env.REACT_APP_BACKEND.replace('/eamlightws/rest', '/cern-eam-services/rest') + `/impact/activities/${impactActivity}`, workorders);
+        return ajax.put(window.environment.REACT_APP_BACKEND_URL.replace('/eamlightws/rest', '/cern-eam-services/rest') + `/impact/activities/${impactActivity}`, workorders);
     }
 
     unlinkWorkorder(workorder, config = {}) {
-        return ajax.delete(process.env.REACT_APP_BACKEND.replace('/eamlightws/rest', '/cern-eam-services/rest') + `/impact/workorders/${workorder}/activity`);
+        return ajax.delete(window.environment.REACT_APP_BACKEND_URL.replace('/eamlightws/rest', '/cern-eam-services/rest') + `/impact/workorders/${workorder}/activity`);
     }
 }
 

--- a/src/ui/components/eqtree/lib/TreeWS.js
+++ b/src/ui/components/eqtree/lib/TreeWS.js
@@ -12,19 +12,19 @@ class TreeWS {
     }
 
     _get(url, config = {}) {
-        return ajax.get(process.env.REACT_APP_BACKEND + url, config);
+        return ajax.get(window.environment.REACT_APP_BACKEND_URL + url, config);
     }
 
     _post(url, data, config = {}) {
-        return ajax.post(process.env.REACT_APP_BACKEND + url, data, config);
+        return ajax.post(window.environment.REACT_APP_BACKEND_URL + url, data, config);
     }
 
     _put(url, data, config = {}) {
-        return ajax.put(process.env.REACT_APP_BACKEND + url, data, config);
+        return ajax.put(window.environment.REACT_APP_BACKEND_URL + url, data, config);
     }
 
     _delete(url, config = {}) {
-        return ajax.delete(process.env.REACT_APP_BACKEND + url, config);
+        return ajax.delete(window.environment.REACT_APP_BACKEND_URL + url, config);
     }
 
 }


### PR DESCRIPTION
Update back-end URL from environment variables at startup time. With this feature the docker image should not be rebuilt with hardcoded URL before usage. This makes the system more kubernetes deployable.

* add and use startup script for back-end url actualization + nginx start as foreground
* add and import configuration javascript
* replace back-end env url references with back-end url coming from the configuration javascript
* readme update