### PR TITLE
Show error + configurable max number of expanded checklist items

### DIFF
--- a/src/ui/pages/work/Workorder.js
+++ b/src/ui/pages/work/Workorder.js
@@ -312,7 +312,7 @@ class Workorder extends Entity {
                                             getWoLink={wo => '/workorder/' + wo}
                                             ref={checklists => this.checklists = checklists}
                                             showSuccess={this.props.showSuccess}
-                                            showError={this.props.showError}/>}
+                                            handleError={this.props.handleError}/>}
 
                                 {!this.props.hiddenRegions[this.getRegions().CUSTOMFIELDS.code] &&
                                   this.props.workOrderLayout.fields.block_5.attribute !== 'H' &&

--- a/src/ui/pages/work/Workorder.js
+++ b/src/ui/pages/work/Workorder.js
@@ -309,6 +309,7 @@ class Workorder extends Entity {
                                 !this.state.layout.newEntity &&
                                 <Checklists workorder={this.state.workorder.number}
                                             printingChecklistLinkToAIS={this.props.applicationData.EL_PRTCL}
+                                            maxExpandedChecklistItems={Math.abs(parseInt(this.props.applicationData.EL_MCHLS)) || 50}
                                             getWoLink={wo => '/workorder/' + wo}
                                             ref={checklists => this.checklists = checklists}
                                             showSuccess={this.props.showSuccess}


### PR DESCRIPTION
This PR enables the Checklists component to display errors when they happen and also passes the maximum number of expanded checklist items configurable option from Infor EAM.