### PR TITLE
[EAM-355] Equipment replacement status autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "core-js": "3.1.4",
     "date-fns": "2.7.0",
     "diacritics": "1.3.0",
-    "eam-components": "git+https://github.com/cern-eam/eam-components.git#v1.2.16",
+    "eam-components": "git+https://github.com/cern-eam/eam-components.git#v1.2.17beta",
     "es6-promise": "4.2.8",
     "iframe-resizer": "3.6.4",
     "jss": "10.0.0",

--- a/src/ui/pages/Entity.js
+++ b/src/ui/pages/Entity.js
@@ -6,6 +6,7 @@ import Ajax from 'eam-components/dist/tools/ajax'
 import ErrorTypes from "../../enums/ErrorTypes";
 import queryString from "query-string";
 import set from "set-value";
+import {assignDefaultValues, assignQueryParamValues} from './EntityTools';
 
 export default class readEntityEquipment extends Component {
 
@@ -337,54 +338,10 @@ export default class readEntityEquipment extends Component {
         let layout = this.settings.layout;
         let layoutPropertiesMap = this.settings.layoutPropertiesMap;
         let queryParams = queryString.parse(window.location.search);
-        return this.assignQueryParamValues(this.assignDefaultValues(entity, layout, layoutPropertiesMap), queryParams)
-    }
 
-    assignQueryParamValues(entity, queryParams) {
-        // Populate the entity object with query params keys matching the custom field code
-        if (entity.customField) {
-            entity.customField.filter(cf => queryParams[cf.code]).forEach(cf => cf.value = queryParams[cf.code])
-        }
-
-        // Create an entity-like object with the values from the query parameters
-        let queryValues = Object.keys(queryParams).reduce( (result, qkey) => {
-            if (qkey.startsWith("udf")) {
-                set(result, `userDefinedFields.${qkey}`, queryParams[qkey])
-            } else {
-                // Transform the query key (qkey) to match exactly the key name in the entity (ekey)
-                result[Object.keys(entity).find(ekey => ekey.toUpperCase() === qkey.toUpperCase())] = queryParams[qkey];
-            }
-            return result;
-        }, {})
-        delete queryValues.undefined;
-
-        return {
-            ...entity,
-            ...queryValues,
-            userDefinedFields: {
-                ...entity.userDefinedFields,
-                ...queryValues.userDefinedFields
-            }
-        }
-    }
-
-    assignDefaultValues(entity, layout, layoutPropertiesMap) {
-        // Create an entity-like object with the default values from the screen's layout
-        let defaultValues = {};
-        if (layout && layoutPropertiesMap) {
-            defaultValues = Object.values(layout.fields)
-                .filter(field => field.defaultValue && layoutPropertiesMap[field.elementId])
-                .reduce((result, field) => set(result, layoutPropertiesMap[field.elementId], field.defaultValue === 'NULL' ? '' : field.defaultValue), {})
-        }
-
-        return {
-            ...entity,
-            ...defaultValues,
-            userDefinedFields: {
-                ...entity.userDefinedFields,
-                ...defaultValues.userDefinedFields
-            }
-        }
+        entity = assignDefaultValues(entity, layout, layoutPropertiesMap);
+        entity = assignQueryParamValues(entity, queryParams);
+        return entity;
     }
 
     //

--- a/src/ui/pages/Entity.js
+++ b/src/ui/pages/Entity.js
@@ -339,9 +339,8 @@ export default class readEntityEquipment extends Component {
         let layoutPropertiesMap = this.settings.layoutPropertiesMap;
         let queryParams = queryString.parse(window.location.search);
 
-        const config = {forced: true};
-        entity = assignDefaultValues(entity, layout, layoutPropertiesMap, config);
-        entity = assignQueryParamValues(entity, queryParams, config);
+        entity = assignDefaultValues(entity, layout, layoutPropertiesMap);
+        entity = assignQueryParamValues(entity, queryParams);
         return entity;
     }
 

--- a/src/ui/pages/Entity.js
+++ b/src/ui/pages/Entity.js
@@ -127,15 +127,15 @@ export default class readEntityEquipment extends Component {
         //
         this.settings.readEntity(code, {cancelToken: this.cancelSource.token})
             .then(response => {
-                this.setState(() => ({
-                    [this.settings.entity]: response.body.data,
-                     readError: null
-                }))
                 this.setLayout({
                     newEntity: false,
                     blocking: false,
                     isModified: false
                 })
+                this.setState(() => ({
+                    [this.settings.entity]: response.body.data,
+                     readError: null
+                }))
                 // Invoke entity specific logic on the subclass
                 this.postRead(response.body.data)
                 // Disable all children when updates not allowed

--- a/src/ui/pages/Entity.js
+++ b/src/ui/pages/Entity.js
@@ -339,8 +339,9 @@ export default class readEntityEquipment extends Component {
         let layoutPropertiesMap = this.settings.layoutPropertiesMap;
         let queryParams = queryString.parse(window.location.search);
 
-        entity = assignDefaultValues(entity, layout, layoutPropertiesMap);
-        entity = assignQueryParamValues(entity, queryParams);
+        const config = {forced: true};
+        entity = assignDefaultValues(entity, layout, layoutPropertiesMap, config);
+        entity = assignQueryParamValues(entity, queryParams, config);
         return entity;
     }
 

--- a/src/ui/pages/Entity.js
+++ b/src/ui/pages/Entity.js
@@ -245,7 +245,7 @@ export default class readEntityEquipment extends Component {
         let code = this.state[this.settings.entity][this.settings.entityCodeProperty];
         this.setLayout({ newEntity: true });
         this.setState({[this.settings.entity]: {
-            ...this.assignDefaultValues(this.state[this.settings.entity],
+            ...assignDefaultValues(this.state[this.settings.entity],
                                         this.settings.layout,
                                         this.settings.layoutPropertiesMap),
             copyFrom: code}});

--- a/src/ui/pages/EntityTools.js
+++ b/src/ui/pages/EntityTools.js
@@ -1,0 +1,99 @@
+
+import set from "set-value";
+
+// clones an entity deeply
+export const cloneEntity = entity => ({
+    ...entity,
+    userDefinedFields: {
+        ...(entity.userDefinedFields || {})
+    },
+    customField: [
+        ...(entity.customField || []).map(cf => ({...cf}))
+    ]
+});
+
+// assigns the user defined fields from userDefinedFields to the entity
+export const assignUserDefinedFields = (entity, userDefinedFields) => {
+    const newEntity = cloneEntity(entity);
+    newEntity.userDefinedFields = Object.assign({}, 
+        ...Object.entries(newEntity.userDefinedFields)
+            .map(([key, value]) => ({[key]: value ? value : userDefinedFields[key]})));
+    return newEntity;
+
+}
+
+// assigns the custom fields from the customField object to the ones that are present in the entity
+// if the specified custom fields are not present in the entity, nothing is done
+export const assignCustomField = (entity, customField) => {
+    const newEntity = cloneEntity(entity);
+    newEntity.customField = newEntity.customField.map(cf => ({...cf,
+        value: ((customField || []).find(cf2 => cf.code === cf2.code) || {}).value || cf.value
+    }));
+    return newEntity;
+}
+
+// assigns the custom fields from the customField object to the entity, merging old values
+export const assignNewCustomField = (entity, customField) => {
+    const newEntity = cloneEntity(entity);
+    newEntity.customField = customField.map(cf => ({...cf,
+        value: ((entity.customField || []).find(cf2 => cf.code == cf2.code) || {}).value || cf.value
+    }));
+    return newEntity;
+}
+
+// assigns the values in values to the entity
+// values that do not exist in the entity are not copied
+// if the entity has a non-empty value, that value is not copied, unless forced is truthy
+export const assignValues = (entity, values, forced) => {
+    const newEntity = cloneEntity(entity);
+    Object.keys(entity)
+        .filter(key => values.hasOwnProperty(key))
+        .forEach(key => {
+            newEntity[key] = forced || !entity[key] ? values[key] : entity[key];
+        });
+
+    return newEntity;
+};
+
+export const assignQueryParamValues = (entity, queryParams) => {
+    // this function converts an object with case insensitive keys to an object with
+    // case sensitive keys, based on a target object
+    const toSensitive = (target, insensitive) => {
+        const mapping = Object.fromEntries(Object.entries(target)
+            .map(([k]) => [k.toLowerCase(), k]));
+
+        return Object.fromEntries(Object.entries(insensitive)
+            .map(([key, value]) => [mapping[key.toLowerCase()], value])
+            .filter(([key]) => key !== undefined));
+    }
+
+    queryParams = {...queryParams};
+
+    // delete values that we cannot touch
+    delete queryParams.userDefinedFields;
+    delete queryParams.customField;
+
+    entity = assignValues(entity, toSensitive(entity, queryParams));
+    entity = assignCustomField(entity, queryParams);
+
+    const userDefinedFields = Object.assign({}, ...Object.entries(queryParams)
+        .filter(([key]) => key.toLowerCase().startsWith("udf")) // only include keys prepended with udf
+        .map(([key, value]) => ({[key.toLowerCase()]: value}))); // remove udf substring at the beginning from key
+
+    return assignUserDefinedFields(entity, userDefinedFields);
+}
+
+export const assignDefaultValues = (entity, layout, layoutPropertiesMap) => {
+    // Create an entity-like object with the default values from the screen's layout
+    let defaultValues = {};
+    if (layout && layoutPropertiesMap) {
+        defaultValues = Object.values(layout.fields)
+            .filter(field => field.defaultValue && layoutPropertiesMap[field.elementId])
+            .map(field => (console.log(field), field))
+            .reduce((result, field) => set(result, layoutPropertiesMap[field.elementId], 
+                    field.defaultValue === 'NULL' ? '' : field.defaultValue), {});
+    }
+
+    entity = assignValues(entity, defaultValues);
+    return assignUserDefinedFields(entity, defaultValues.userDefinedFields);
+}

--- a/src/ui/pages/EntityTools.js
+++ b/src/ui/pages/EntityTools.js
@@ -102,7 +102,7 @@ export const assignQueryParamValues = (entity, queryParams, config = {forced: tr
     return assignUserDefinedFields(entity, userDefinedFields, config);
 }
 
-export const assignDefaultValues = (entity, layout, layoutPropertiesMap, config = {forced: false}) => {
+export const assignDefaultValues = (entity, layout, layoutPropertiesMap, config = {forced: true}) => {
     // Create an entity-like object with the default values from the screen's layout
     let defaultValues = {};
     if (layout && layoutPropertiesMap) {

--- a/src/ui/pages/EntityTools.js
+++ b/src/ui/pages/EntityTools.js
@@ -1,4 +1,3 @@
-
 import set from "set-value";
 
 // clones an entity deeply
@@ -12,26 +11,72 @@ export const cloneEntity = entity => ({
     ]
 });
 
+// There are 3 kinds of entity assignments:
+// 1. always copy from source to destination (FORCED)
+//      - used when you wish to force an assignment
+// 2. copy from source to destination if source is not empty (SOURCE_NOT_EMPTY)
+//      - used when you wish to assign only if you have something to assign
+//        (trying to assign an empty value to an existing one will not change it)
+// 3. copy from source to destination if destination is empty (DESTINATION_EMPTY)
+//      - used when you wish to assign only if what you are assigning to is empty
+//        (trying to assign an existing value to another existing value will not change it)
+export const AssignmentType = {
+    FORCED: {
+        sourceNotEmpty: false,
+        destinationEmpty: false
+    },
+    SOURCE_NOT_EMPTY: {
+        sourceNotEmpty: true,
+        destinationEmpty: false
+    },
+    DESTINATION_EMPTY: {
+        sourceNotEmpty: false,
+        destinationEmpty: true
+    }
+    // Note: there is no combination where both sourceNotEmpty and destinationEmpty are true
+    // because this is effectively the same as DESTINATION_EMPTY, as if the source is empty,
+    // it will not change an empty destination anyway
+};
+
+const throwIfInvalidAssignmentType = assignmentType => {
+    if(!Object.values(AssignmentType).includes(assignmentType))
+        throw new Error('You must specify a valid assigment type');
+};
+
 // assigns the user defined fields from userDefinedFields to the entity
-export const assignUserDefinedFields = (entity, userDefinedFields, {forced = false} = {}) => {
+export const assignUserDefinedFields = (entity, userDefinedFields, assignmentType) => {
+    throwIfInvalidAssignmentType(assignmentType);
+    const {sourceNotEmpty, destinationEmpty} = assignmentType;
+
     const newEntity = cloneEntity(entity);
     let expr = Object.entries(userDefinedFields);
 
-    if(!forced) {
+    if(sourceNotEmpty) {
+        expr = expr.filter(([, value]) => value);
+    }
+
+    if(destinationEmpty) {
         expr = expr.filter(([key]) => !newEntity.userDefinedFields[key])
     }
-    
+
     expr.forEach(([key, value]) => newEntity.userDefinedFields[key] = value);
     return newEntity;
 }
 
 // assigns the custom fields from an object to the ones that are present in the entity
 // if the specified custom fields are not present in the entity, nothing is done
-export const assignCustomFieldFromObject = (entity, object, {forced = false} = {}) => {
+export const assignCustomFieldFromObject = (entity, object, assignmentType) => {
+    throwIfInvalidAssignmentType(assignmentType);
+    const {sourceNotEmpty, destinationEmpty} = assignmentType;
+
     const newEntity = cloneEntity(entity);
     let expr = newEntity.customField.filter(cf => object[cf.code]);
 
-    if(!forced) {
+    if(sourceNotEmpty) {
+        expr = expr.filter(cf => object[cf.code]);
+    }
+
+    if(destinationEmpty) {
         expr = expr.filter(cf => !cf.value);
     }
 
@@ -40,41 +85,58 @@ export const assignCustomFieldFromObject = (entity, object, {forced = false} = {
 }
 
 // assigns the custom fields from the customField object to the entity, merging old values
-export const assignCustomFieldFromCustomField = (entity, customField, {forced = false} = {}) => {
+export const assignCustomFieldFromCustomField = (entity, customField, assignmentType) => {
+    throwIfInvalidAssignmentType(assignmentType);
+    const {sourceNotEmpty, destinationEmpty} = assignmentType;
+
     const newEntity = cloneEntity(entity);
     const oldCustomField = newEntity.customField;
     newEntity.customField = customField.map(cf => ({...cf})); // ensure custom field is not modified
 
-    if(forced) {
-        return newEntity;
+    let expr = newEntity.customField;
+    
+    if(sourceNotEmpty) {
+        expr = expr.filter(cf => !cf.value);
     }
 
-    const getOldCustomField = ({code}) => oldCustomField.find(cf => code === cf.code);
+    const getOldCustomFieldValue = ({code}) => {
+        const field = oldCustomField.find(cf => code === cf.code);
+        return field ? field.value : undefined;
+    }
 
-    newEntity.customField.filter(cf => {
-            const field = getOldCustomField(cf);
-            return field && field.value;
-        }).forEach(cf => cf.value = getOldCustomField(cf).value);
-
+    if(destinationEmpty) {
+        expr = expr.filter(cf => getOldCustomFieldValue(cf));
+    }
+    
+    expr.forEach(cf => cf.value = getOldCustomFieldValue(cf));
     return newEntity;
 }
 
 // assigns the values in values to the entity
 // values that do not exist in the entity are not copied
 // if the entity has a non-empty value, that value is not copied, unless forced is truthy
-export const assignValues = (entity, values, {forced = false} = {}) => {
+export const assignValues = (entity, values, assignmentType) => {
+    throwIfInvalidAssignmentType(assignmentType);
+    const {sourceNotEmpty, destinationEmpty} = assignmentType;
+
     const newEntity = cloneEntity(entity);
     let expr = Object.keys(newEntity).filter(key => values.hasOwnProperty(key));
 
-    if(!forced) {
+    if(destinationEmpty) {
         expr = expr.filter(key => !newEntity[key]);
+    }
+
+    if(sourceNotEmpty) {
+        expr = expr.filter(key => values[key]);
     }
 
     expr.forEach(key => newEntity[key] = values[key]);
     return newEntity;
 };
 
-export const assignQueryParamValues = (entity, queryParams, config = {forced: true}) => {
+export const assignQueryParamValues = (entity, queryParams, assignmentType = AssignmentType.FORCED) => {
+    throwIfInvalidAssignmentType(assignmentType);
+
     // this function converts an object with case insensitive keys to an object with
     // case sensitive keys, based on a target object
     const toSensitive = (target, insensitive) => {
@@ -92,17 +154,19 @@ export const assignQueryParamValues = (entity, queryParams, config = {forced: tr
     delete caseSensitiveQueryParams.userDefinedFields;
     delete caseSensitiveQueryParams.customField;
 
-    entity = assignValues(entity, caseSensitiveQueryParams, config);
-    entity = assignCustomFieldFromObject(entity, queryParams, config);
+    entity = assignValues(entity, caseSensitiveQueryParams, assignmentType);
+    entity = assignCustomFieldFromObject(entity, queryParams, assignmentType);
 
     const userDefinedFields = Object.assign({}, ...Object.entries(queryParams)
         .filter(([key]) => key.toLowerCase().startsWith("udf")) // only include keys prepended with udf
         .map(([key, value]) => ({[key.toLowerCase()]: value}))); // remove udf substring at the beginning from key
 
-    return assignUserDefinedFields(entity, userDefinedFields, config);
+    return assignUserDefinedFields(entity, userDefinedFields, assignmentType);
 }
 
-export const assignDefaultValues = (entity, layout, layoutPropertiesMap, config = {forced: true}) => {
+export const assignDefaultValues = (entity, layout, layoutPropertiesMap, assignmentType = AssignmentType.FORCED) => {
+    throwIfInvalidAssignmentType(assignmentType);
+
     // Create an entity-like object with the default values from the screen's layout
     let defaultValues = {};
     if (layout && layoutPropertiesMap) {
@@ -112,6 +176,6 @@ export const assignDefaultValues = (entity, layout, layoutPropertiesMap, config 
                     field.defaultValue === 'NULL' ? '' : field.defaultValue), {});
     }
 
-    entity = assignValues(entity, defaultValues, config);
-    return assignUserDefinedFields(entity, defaultValues.userDefinedFields, config);
+    entity = assignValues(entity, defaultValues, assignmentType);
+    return assignUserDefinedFields(entity, defaultValues.userDefinedFields, assignmentType);
 }

--- a/src/ui/pages/EntityTools.js
+++ b/src/ui/pages/EntityTools.js
@@ -41,16 +41,21 @@ export const assignCustomFieldFromObject = (entity, object, {forced = false} = {
 
 // assigns the custom fields from the customField object to the entity, merging old values
 export const assignCustomFieldFromCustomField = (entity, customField, {forced = false} = {}) => {
-    const getCustomField = code => customField.find(cf => code === cf.code);
-
     const newEntity = cloneEntity(entity);
-    let expr = newEntity.customField.filter(cf => getCustomField(cf.code));
-    
-    if(!forced) {
-        expr = expr.filter(cf => !cf.value);
+    const oldCustomField = newEntity.customField;
+    newEntity.customField = customField.map(cf => ({...cf})); // ensure custom field is not modified
+
+    if(forced) {
+        return newEntity;
     }
 
-    expr.forEach(cf => cf.value = getCustomField(cf.code).value);
+    const getOldCustomField = ({code}) => oldCustomField.find(cf => code === cf.code);
+
+    newEntity.customField.filter(cf => {
+            const field = getOldCustomField(cf);
+            return field && field.value;
+        }).forEach(cf => cf.value = getOldCustomField(cf).value);
+
     return newEntity;
 }
 

--- a/src/ui/pages/equipment/replaceeqp/ReplaceEqp.js
+++ b/src/ui/pages/equipment/replaceeqp/ReplaceEqp.js
@@ -149,9 +149,9 @@ class ReplaceEqp extends Component {
                                                    showError={this.props.showError}/>
                             </Grid>
                             <Grid item sm={6} xs={12}>
-                                <ReplaceEqpHierarchy equipment={this.state.oldEquipment} title="OLD EQUIPMENT HIERARCHY"
+                                <ReplaceEqpHierarchy equipment={this.state.oldEquipment} title="CURRENT HIERARCHY OF THE OLD EQUIPMENT"
                                                      equipmentLayout={this.props.equipmentLayout}/>
-                                <ReplaceEqpHierarchy equipment={this.state.newEquipment} title="NEW EQUIPMENT HIERARCHY"
+                                <ReplaceEqpHierarchy equipment={this.state.newEquipment} title="CURRENT HIERARCHY OF THE NEW EQUIPMENT"
                                                      equipmentLayout={this.props.equipmentLayout}/>
                             </Grid>
                         </Grid>

--- a/src/ui/pages/equipment/replaceeqp/ReplaceEqpGeneral.js
+++ b/src/ui/pages/equipment/replaceeqp/ReplaceEqpGeneral.js
@@ -112,14 +112,14 @@ class ReplaceEqpGeneral extends Component {
                             attribute: "R",
                             text: "Old Equipment", xpath: "OldEquipment"
                         }}
-                                         value={this.props.replaceEquipment.oldEquipment}
-                                         updateProperty={this.props.updateProperty}
-                                         valueKey="oldEquipment"
-                                         autocompleteHandler={WSEquipment.autocompleteEquipmentReplacement}
-                                         onChangeValue={this.props.onChangeOldEquipment}
-                                         children={this.children}
-                                         valueDesc={this.props.replaceEquipment.oldEquipmentDesc}
-                                         descKey="oldEquipmentDesc"/>
+                            value={this.props.replaceEquipment.oldEquipment}
+                            updateProperty={this.props.updateProperty}
+                            valueKey="oldEquipment"
+                            autocompleteHandler={WSEquipment.autocompleteEquipmentReplacement}
+                            onChangeValue={this.props.onChangeOldEquipment}
+                            children={this.children}
+                            valueDesc={this.props.replaceEquipment.oldEquipmentDesc}
+                            descKey="oldEquipmentDesc"/>
                     </EAMBarcodeInput>
 
                     <EAMSelect
@@ -141,14 +141,14 @@ class ReplaceEqpGeneral extends Component {
                             attribute: "R",
                             text: "New Equipment", xpath: "NewEquipment"
                         }}
-                                         value={this.props.replaceEquipment.newEquipment}
-                                         updateProperty={this.props.updateProperty}
-                                         valueKey="newEquipment"
-                                         autocompleteHandler={WSEquipment.autocompleteEquipmentReplacement}
-                                         onChangeValue={this.props.onChangeNewEquipment}
-                                         children={this.children}
-                                         valueDesc={this.props.replaceEquipment.newEquipmentDesc}
-                                         descKey="newEquipmentDesc"/>
+                            value={this.props.replaceEquipment.newEquipment}
+                            updateProperty={this.props.updateProperty}
+                            valueKey="newEquipment"
+                            autocompleteHandler={WSEquipment.autocompleteEquipmentReplacement}
+                            onChangeValue={this.props.onChangeNewEquipment}
+                            children={this.children}
+                            valueDesc={this.props.replaceEquipment.newEquipmentDesc}
+                            descKey="newEquipmentDesc"/>
                     </EAMBarcodeInput>
 
                     {this.renderImageMode()}

--- a/src/ui/pages/equipment/replaceeqp/ReplaceEqpGeneral.js
+++ b/src/ui/pages/equipment/replaceeqp/ReplaceEqpGeneral.js
@@ -126,13 +126,14 @@ class ReplaceEqpGeneral extends Component {
                         elementInfo={{
                             ...this.props.equipmentLayout.fields['assetstatus'],
                             attribute: "R",
-                            text: "Old Equipment Status after replacement"
+                            text: "Old Equipment Status after replacement",
+                            readonly: this.props.statusList.length === 0
                         }}
                         valueKey="oldEquipmentStatus"
                         values={this.props.statusList}
                         value={this.props.replaceEquipment.oldEquipmentStatus}
                         updateProperty={this.props.updateProperty}
-                        children={this.children}/>
+                        children={this.children} />
 
                     <EAMBarcodeInput updateProperty={value => this.props.updateProperty('newEquipment', value)} right={0} top={20}>
                         <EAMAutocomplete elementInfo={{

--- a/src/ui/pages/work/Workorder.js
+++ b/src/ui/pages/work/Workorder.js
@@ -221,17 +221,18 @@ class Workorder extends Entity {
         this.checklists.readActivities(this.state.workorder.number);
     };
 
-    readStandardWorkOrder = async standardWorkOrderCode => {
-        if (!standardWorkOrderCode) {
+    readStandardWorkOrder = (standardWorkOrderCode, firstTime) => {
+        if (!standardWorkOrderCode || ((firstTime && !this.state.layout.newEntity))) {
             return;
         }
 
-        const response = await WSWorkorder.getStandardWorkOrder(standardWorkOrderCode);
-        const standardWorkOrder = response.body.data;
+        WSWorkorder.getStandardWorkOrder(standardWorkOrderCode).then(response => {
+            const standardWorkOrder = response.body.data;
         
-        this.setState(state => ({
-            workorder: assignStandardWorkOrderValues({...state.workorder}, standardWorkOrder)
-        }));
+            this.setState(state => ({
+                workorder: assignStandardWorkOrderValues({...state.workorder}, standardWorkOrder)
+            }));
+        })
     }
 
     //
@@ -286,7 +287,8 @@ class Workorder extends Entity {
                                     {...props}
                                     readStandardWorkOrder={this.readStandardWorkOrder}
                                     applicationData={this.props.applicationData} 
-                                    userData={this.props.userData} />
+                                    userData={this.props.userData} 
+                                    newEntity={this.state.layout.newEntity} />
 
                                 {!this.props.hiddenRegions[this.getRegions().SCHEDULING.code] &&
                                 WorkorderTools.isRegionAvailable('SCHEDULING', props.workOrderLayout) &&

--- a/src/ui/pages/work/Workorder.js
+++ b/src/ui/pages/work/Workorder.js
@@ -21,26 +21,24 @@ import WorkorderClosingCodes from './WorkorderClosingCodes';
 import WorkorderDetails from './WorkorderGeneral';
 import WorkorderScheduling from './WorkorderScheduling';
 import WorkorderTools from "./WorkorderTools";
-import {assignValues, assignUserDefinedFields, assignCustomFieldFromCustomField} from '../EntityTools';
+import {assignValues, assignUserDefinedFields, assignCustomFieldFromCustomField, AssignmentType} from '../EntityTools';
 
 const assignStandardWorkOrderValues = (workOrder, standardWorkOrder) => {
     const swoToWoMap = ([k, v]) => [k, standardWorkOrder[v]];
 
-    // forced assign values
     workOrder = assignValues(workOrder, Object.fromEntries([
         ['classCode', 'woClassCode'],
         ['typeCode', 'workOrderTypeCode'],
         ['problemCode', 'problemCode'],
         ['priorityCode', 'priorityCode']
-    ].map(swoToWoMap)), {forced: true});
+    ].map(swoToWoMap)), AssignmentType.SOURCE_NOT_EMPTY);
 
-    // non-forced assign values
     workOrder = assignValues(workOrder, Object.fromEntries([
         ['description', 'desc'],
-    ].map(swoToWoMap)));
+    ].map(swoToWoMap)), AssignmentType.DESTINATION_EMPTY);
 
-    workOrder = assignUserDefinedFields(workOrder, standardWorkOrder.userDefinedFields);
-    workOrder = assignCustomFieldFromCustomField(workOrder, standardWorkOrder.customField);
+    workOrder = assignUserDefinedFields(workOrder, standardWorkOrder.userDefinedFields, AssignmentType.DESTINATION_EMPTY);
+    workOrder = assignCustomFieldFromCustomField(workOrder, standardWorkOrder.customField, AssignmentType.DESTINATION_EMPTY);
 
     return workOrder;
 };

--- a/src/ui/pages/work/Workorder.js
+++ b/src/ui/pages/work/Workorder.js
@@ -21,10 +21,10 @@ import WorkorderClosingCodes from './WorkorderClosingCodes';
 import WorkorderDetails from './WorkorderGeneral';
 import WorkorderScheduling from './WorkorderScheduling';
 import WorkorderTools from "./WorkorderTools";
-import {assignValues, assignUserDefinedFields, assignNewCustomField} from '../EntityTools';
+import {assignValues, assignUserDefinedFields, assignCustomFieldFromCustomField} from '../EntityTools';
 
 const assignStandardWorkOrderValues = (workOrder, standardWorkOrder) => {
-    const swo = swoKey => standardWorkOrder[swoKey];
+    const swoToWoMap = ([k, v]) => [k, standardWorkOrder[v]];
 
     // forced assign values
     workOrder = assignValues(workOrder, Object.fromEntries([
@@ -32,15 +32,15 @@ const assignStandardWorkOrderValues = (workOrder, standardWorkOrder) => {
         ['typeCode', 'workOrderTypeCode'],
         ['problemCode', 'problemCode'],
         ['priorityCode', 'priorityCode']
-    ].map(([k, v]) => [k, swo(v)])), true);
+    ].map(swoToWoMap), {forced: true}));
 
     // non-forced assign values
     workOrder = assignValues(workOrder, Object.fromEntries([
         ['description', 'desc'],
-    ].map(([k, v]) => [k, swo(v)])));
+    ].map(swoToWoMap)));
 
     workOrder = assignUserDefinedFields(workOrder, standardWorkOrder.userDefinedFields);
-    workOrder = assignNewCustomField(workOrder, standardWorkOrder.customField);
+    workOrder = assignCustomFieldFromCustomField(workOrder, standardWorkOrder.customField);
 
     return workOrder;
 };

--- a/src/ui/pages/work/Workorder.js
+++ b/src/ui/pages/work/Workorder.js
@@ -32,7 +32,7 @@ const assignStandardWorkOrderValues = (workOrder, standardWorkOrder) => {
         ['typeCode', 'workOrderTypeCode'],
         ['problemCode', 'problemCode'],
         ['priorityCode', 'priorityCode']
-    ].map(swoToWoMap), {forced: true}));
+    ].map(swoToWoMap)), {forced: true});
 
     // non-forced assign values
     workOrder = assignValues(workOrder, Object.fromEntries([

--- a/src/ui/pages/work/WorkorderGeneral.js
+++ b/src/ui/pages/work/WorkorderGeneral.js
@@ -7,10 +7,11 @@ import EAMAutocomplete from 'eam-components/dist/ui/components/muiinputs/EAMAuto
 import WS from '../../../tools/WS'
 import UDFChar from "../../components/userdefinedfields/UDFChar";
 import EAMBarcodeInput from "eam-components/dist/ui/components/muiinputs/EAMBarcodeInput";
+import WSWorkorders from "../../../tools/WSWorkorders"
 
 function WorkorderDetails(props) {
 
-    const { children, workOrderLayout, workorder, updateWorkorderProperty, layout, applicationData, setWOEquipment } = props;
+    const { children, workOrderLayout, workorder, updateWorkorderProperty, layout, applicationData, setWOEquipment, userData } = props;
     const rpawClassesList = (applicationData && applicationData.EL_TRPAC && applicationData.EL_TRPAC.split(',')) || [];
     const rpawLink = applicationData && applicationData.EL_TRPAW;
 
@@ -115,15 +116,15 @@ function WorkorderDetails(props) {
                                  updateProperty={updateWorkorderProperty}
                                  autocompleteHandler={(filter, config) => WS.autocompleteClass('EVNT', filter, config)}/>
 
-                {/*<EAMAutocomplete children={children}*/}
-                                 {/*elementInfo={workOrderLayout.fields['standardwo']}*/}
-                                 {/*value={workorder.standardWO}*/}
-                                 {/*valueKey="standardWO"*/}
-                                 {/*valueDesc={workorder.standardWODesc}*/}
-                                 {/*descKey="standardWODesc"*/}
-                                 {/*updateProperty={updateWorkorderProperty}*/}
-                                 {/*onChangeValue={props.readStandardWorkOrder}*/}
-                                 {/*autocompleteHandler={WSWorkorders.autocompleteStandardWorkOrder.bind(null, userData.eamAccount.userGroup)}/>*/}
+                <EAMAutocomplete children={children}
+                    elementInfo={workOrderLayout.fields['standardwo']}
+                    value={workorder.standardWO}
+                    valueKey="standardWO"
+                    valueDesc={workorder.standardWODesc}
+                    descKey="standardWODesc"
+                    updateProperty={updateWorkorderProperty}
+                    onChangeValue={props.readStandardWorkOrder}
+                    autocompleteHandler={WSWorkorders.autocompleteStandardWorkOrder.bind(null, userData.eamAccount.userGroup)}/>
 
                 <EAMInput
                         elementInfo={{...workOrderLayout.fields['parentwo'], readonly: true}}

--- a/src/ui/pages/work/WorkorderGeneral.js
+++ b/src/ui/pages/work/WorkorderGeneral.js
@@ -11,11 +11,15 @@ import WSWorkorders from "../../../tools/WSWorkorders"
 
 function WorkorderDetails(props) {
 
-    const { children, workOrderLayout, workorder, updateWorkorderProperty, layout, applicationData, setWOEquipment, userData } = props;
+    const { children, workOrderLayout, workorder, updateWorkorderProperty, layout, applicationData, setWOEquipment, userData, newEntity } = props;
     const rpawClassesList = (applicationData && applicationData.EL_TRPAC && applicationData.EL_TRPAC.split(',')) || [];
     const rpawLink = applicationData && applicationData.EL_TRPAW;
 
-    let onChangeEquipment = (value) => {
+    let onChangeEquipment = (value, firstTime) => {
+        if(firstTime && !newEntity) {
+            return;
+        }
+
         //If there is a value, fetch location, department, cost code
         //and custom fields
         if (value) {


### PR DESCRIPTION
The following changes were made:
* Status autocomplete works according to user group and old equipment status
* Cannot change status if old equipment is not filled in
* Relabeled the titles for the old hierarchy and new hierarchy, so it is clear what they represent
* Minor refactoring

**Merge only after #37**