### PR TITLE
[EAM-934] Show Events tab of extended in Work Orders of Equipment

### DIFF
--- a/src/tools/WSEquipment.js
+++ b/src/tools/WSEquipment.js
@@ -16,6 +16,10 @@ class WSEquipment {
         return WS._get('/equipment/workorders?c=' + equipmentCode, config);
     }
 
+    getEquipmentEvents(equipmentCode, config = {}) {
+        return WS._get('/equipment/events?c=' + equipmentCode, config);
+    }
+
     getEquipment(equipmentCode, config = {}) {
         equipmentCode = encodeURIComponent(equipmentCode);
         return WS._get('/equipment?c=' + equipmentCode, config);


### PR DESCRIPTION
Note: the size at which the `EntityRegions` component uses 2 columns instead of 1 was changed from 960px to 1280px, to be able to fit the Events table in a readable way.