### PR TITLE
[RQF-1754428] Add creation date to equipment work orders, hide completed work orders when 'Open' is selected

### DIFF
--- a/src/ui/pages/equipment/components/EquipmentWorkOrders.js
+++ b/src/ui/pages/equipment/components/EquipmentWorkOrders.js
@@ -23,7 +23,7 @@ const WO_FILTERS = {
     [WO_FILTER_TYPES.OPEN]: {
         text: WO_FILTER_TYPES.OPEN,
         process: (data) => {
-            return data.filter((workOrder) => workOrder.status && !workOrder.status.startsWith("T"));
+            return data.filter((workOrder) => workOrder.status && ['T', 'C'].every(statusCode => !workOrder.status.startsWith(statusCode)));
         }
     },
     [WO_FILTER_TYPES.MTF]: {
@@ -48,8 +48,8 @@ function EquipmentWorkOrders(props) {
     let [workOrderFilter, setWorkOrderFilter] = useState(Object.values(WO_FILTER_TYPES).includes(defaultFilter) ? defaultFilter : WO_FILTER_TYPES.ALL)
     const [loadingData, setLoadingData] = useState(true);
 
-    let headers = ['Work Order', 'Equipment', 'Description', 'Status'];
-    let propCodes = ['number', 'object','desc', 'status'];
+    let headers = ['Work Order', 'Equipment', 'Description', 'Status', 'Creation Date'];
+    let propCodes = ['number', 'object','desc', 'status', 'createdDate'];
 
     if (workOrderFilter === WO_FILTER_TYPES.THIS) {
         headers = ['Work Order', 'Description', 'Status', 'Creation Date'];


### PR DESCRIPTION
Behavior of table on different screen resolutions:
![image](https://user-images.githubusercontent.com/60660227/109290834-6bf25280-7828-11eb-9150-fc0c5ff18743.png)
![image](https://user-images.githubusercontent.com/60660227/109290846-70b70680-7828-11eb-8881-8e9ffdf7c0ca.png)
![image](https://user-images.githubusercontent.com/60660227/109290870-77de1480-7828-11eb-9baa-bbb2344f9024.png)

Behavior when selecting 'All' and 'Open' in equipment work orders:
![image](https://user-images.githubusercontent.com/60660227/109290936-92b08900-7828-11eb-8a74-64c5b8f340fb.png)
![image](https://user-images.githubusercontent.com/60660227/109290947-97753d00-7828-11eb-9e7d-de81db68d828.png)
