### PR TITLE
[EAM-221] Make the content on the sub menu scrollable

### DIFF
--- a/src/ui/layout/menu/EamlightMenu.css
+++ b/src/ui/layout/menu/EamlightMenu.css
@@ -64,11 +64,12 @@
   }
 
   .layout-tab-submenu>li {
-    display: flex;
-    flex-flow: column;
+    display: block;
     margin: 0px;
     padding: 0px;
-    max-height: 85vh;
+    position: absolute;
+    width: inherit;
+    height: 100%;
   }
 
   .layout-tab-submenu>li:first-child {
@@ -88,7 +89,25 @@
     margin: 0px;
     padding: 0px;
     overflow-y: scroll;
-    flex: 1;
+    height: 80%;
+    scrollbar-color: transparent transparent;
+  }
+
+  @media only screen and (max-height: 450px) {
+    .layout-tab-submenu>li ul {
+      height: 60%;
+    }
+  }
+
+  @media only screen and (min-height: 451px) and (max-height: 660px) {
+    .layout-tab-submenu>li ul {
+      height: 70%;
+    }
+  }
+
+  .layout-tab-submenu>li ul::-webkit-scrollbar {
+    width: 0 !important;
+    display: none;
   }
 
   .layout-tab-submenu>li ul li {
@@ -137,7 +156,6 @@
     right: 0;
     bottom: 0;
     left: 0;
-    position: relative;
     background-color: #242021;
   }
 

--- a/src/ui/layout/menu/EamlightMenu.css
+++ b/src/ui/layout/menu/EamlightMenu.css
@@ -14,7 +14,6 @@
   #layout-tab-menu>li {
     width: 58px;
     height: 50px;
-    
   }
 
   #layout-tab-menu>li:first-child {
@@ -56,7 +55,7 @@
     min-height: 100%;
     margin-left: 58px;
     background-color: #282828;
-    padding-bottom: 100px;
+    padding-bottom: 0;
     display: none;
   }
 
@@ -65,10 +64,11 @@
   }
 
   .layout-tab-submenu>li {
-    display: block;
+    display: flex;
+    flex-flow: column;
     margin: 0px;
     padding: 0px;
-    margin-bottom: 10px;
+    max-height: 85vh;
   }
 
   .layout-tab-submenu>li:first-child {
@@ -87,7 +87,8 @@
   .layout-tab-submenu>li ul {
     margin: 0px;
     padding: 0px;
-    display: block;
+    overflow-y: scroll;
+    flex: 1;
   }
 
   .layout-tab-submenu>li ul li {

--- a/src/ui/layout/menu/EamlightMenu.css
+++ b/src/ui/layout/menu/EamlightMenu.css
@@ -95,13 +95,19 @@
 
   @media only screen and (max-height: 450px) {
     .layout-tab-submenu>li ul {
-      height: 60%;
+      height: 80%;
+    }
+    .layout-tab-submenu>li> span + div + ul {
+      height: 67%;
     }
   }
 
   @media only screen and (min-height: 451px) and (max-height: 660px) {
     .layout-tab-submenu>li ul {
-      height: 70%;
+      height: 82%;
+    }
+    .layout-tab-submenu>li> span + div + ul {
+      height: 75%;
     }
   }
 

--- a/src/ui/layout/menu/EamlightMenu.css
+++ b/src/ui/layout/menu/EamlightMenu.css
@@ -89,26 +89,12 @@
     margin: 0px;
     padding: 0px;
     overflow-y: scroll;
-    height: 80%;
+    height: calc(100% - 95px);
     scrollbar-color: transparent transparent;
   }
 
-  @media only screen and (max-height: 450px) {
-    .layout-tab-submenu>li ul {
-      height: 80%;
-    }
-    .layout-tab-submenu>li> span + div + ul {
-      height: 67%;
-    }
-  }
-
-  @media only screen and (min-height: 451px) and (max-height: 660px) {
-    .layout-tab-submenu>li ul {
-      height: 82%;
-    }
-    .layout-tab-submenu>li> span + div + ul {
-      height: 75%;
-    }
+  .layout-tab-submenu>li> span + div + ul {
+    height: calc(100% - 150px);
   }
 
   .layout-tab-submenu>li ul::-webkit-scrollbar {


### PR DESCRIPTION
This pull request makes the content of the tab menu on the left side of the screen scrollable.
I decided to use viewport height as the height unit, as it seems to work nicely. It has a nice support amongst browsers as well https://caniuse.com/viewport-units

Support for flex is also good, https://caniuse.com/flexbox, it could be utilized more.

I removed the bottom padding as it seemed a bit unnecessary, but it can be put back if it's an issue.