### PR TITLE
[EAM-1692] Fixed URL parameter

### DIFF
--- a/src/ui/pages/work/Workorder.js
+++ b/src/ui/pages/work/Workorder.js
@@ -364,7 +364,7 @@ class Workorder extends Entity {
                         userCode={userData.eamAccount.userCode}
                         disabled={this.departmentalSecurity.readOnly}
                         hideFilledItems={panelQueryParams.hideFilledItems === 'true'}
-                        activity={panelQueryParams.activity}
+                        activity={panelQueryParams.CHECKLISTSactivity}
                         topSlot={
                             applicationData.EL_PRTCL &&
                                 <div style={{


### PR DESCRIPTION
The functionality described in EAM-1692 was previously implemented in the eam-components library, but the activity query parameter was not correctly passed to the component. This is the fix for that.