### PR TITLE
[EAM-2295] Fix key warning from menu

### DIFF
--- a/src/ui/layout/menu/EamlightMenu.js
+++ b/src/ui/layout/menu/EamlightMenu.js
@@ -379,8 +379,9 @@ class EamlightMenu extends Component {
 
                     {reports &&
                     <EamlightSubmenu id="customgrids" header={<span>CUSTOM GRIDS</span>}>
-                        {reports.map( report => (
-                            <MenuGridLink grid={report}/>
+                        {
+                        reports.map( report => (
+                            <MenuGridLink grid={report} key={report?.code} />
                             ))
                         }
                     </EamlightSubmenu>


### PR DESCRIPTION
Depends on https://github.com/cern-eam/eam-light-backend/pull/96 to avoid having duplicate key warning.