### PR TITLE
[EAM-1773] Rename hide follow up prop to avoid confusion with `hideFollowUp` propriety in activities' checklists

### DIFF
--- a/src/ui/pages/work/Workorder.js
+++ b/src/ui/pages/work/Workorder.js
@@ -395,7 +395,7 @@ const Workorder = () => {
                         handleError={handleError}
                         userCode={userData.eamAccount.userCode}
                         disabled={readOnly}
-                        disableCreateFollowUp={isHidden(
+                        hideFollowUpProp={isHidden(
                             commonProps.workOrderLayout.tabs.ACK.fields.createfollowupwo
                         )}
                         hideFilledItems={panelQueryParams.CHECKLISTShideFilledItems === 'true'}


### PR DESCRIPTION
Relates to:

- https://github.com/cern-eam/eam-components/pull/129