### PR TITLE
[EAM-2286] Reset error messages state

### DIFF
--- a/src/ui/pages/work/activities/Activity.js
+++ b/src/ui/pages/work/activities/Activity.js
@@ -15,7 +15,7 @@ function Activity(props) {
 
     const { activity, bookLabours, layout, readActivities, postAddActivityHandler, handleError } = props;
 
-    const [isEditModalOpen, setIsEditModalOpen] = useState();
+    const [isEditModalOpen, setIsEditModalOpen] = useState(false);
     const [loading, setLoading] = useState(false);
     const [anchorEl, setAnchorEl] = useState(null);
     const open = Boolean(anchorEl);
@@ -125,8 +125,6 @@ function Activity(props) {
                     </Grid>
                     <Stack
                         className="activityDetails"
-                        item
-                        container
                         spacing={1}
                         direction="row"
                         justifyContent="space-between"

--- a/src/ui/pages/work/activities/dialogs/AddActivityDialog.js
+++ b/src/ui/pages/work/activities/dialogs/AddActivityDialog.js
@@ -46,10 +46,9 @@ function AddActivityDialog(props) {
             } else {
                 init();
             }
-        }
-        return () => {
+        } else {
             resetErrorMessages();
-        };
+        }
     }, [props.open]);
 
     let init = () => {

--- a/src/ui/pages/work/activities/dialogs/AddActivityDialog.js
+++ b/src/ui/pages/work/activities/dialogs/AddActivityDialog.js
@@ -36,10 +36,8 @@ function AddActivityDialog(props) {
         endDate: layout.actenddate,
     };
 
-    const { errorMessages, validateFields } = useFieldsValidator(
-        fieldsData,
-        formValues
-    );
+    const { errorMessages, validateFields, resetErrorMessages } =
+        useFieldsValidator(fieldsData, formValues);
 
     useEffect(() => {
         if (props.open) {
@@ -49,6 +47,9 @@ function AddActivityDialog(props) {
                 init();
             }
         }
+        return () => {
+            resetErrorMessages();
+        };
     }, [props.open]);
 
     let init = () => {

--- a/src/ui/pages/work/partusage/PartUsageDialog.js
+++ b/src/ui/pages/work/partusage/PartUsageDialog.js
@@ -97,8 +97,7 @@ function PartUsageDialog(props) {
     useEffect(() => {
         if (isDialogOpen) {
             initNewPartUsage();
-        }
-        return () => {
+        } else {
             setUoM('');
             resetFormTransactionLinesAndBinListStates();
             resetErrorMessages();

--- a/src/ui/pages/work/partusage/PartUsageDialog.js
+++ b/src/ui/pages/work/partusage/PartUsageDialog.js
@@ -70,10 +70,8 @@ function PartUsageDialog(props) {
         transactionQty: tabLayout.transactionquantity,
     };
 
-    const { errorMessages, validateFields } = useFieldsValidator(
-        fieldsData,
-        formData
-    );
+    const { errorMessages, validateFields, resetErrorMessages } =
+        useFieldsValidator(fieldsData, formData);
 
     const updateFormDataProperty = (key, value) => {
         setFormData((oldFormData) => ({
@@ -103,6 +101,7 @@ function PartUsageDialog(props) {
         return () => {
             setUoM('');
             resetFormTransactionLinesAndBinListStates();
+            resetErrorMessages();
         }
     }, [isDialogOpen]);
 


### PR DESCRIPTION
Since the dialog is being rendered by the `Activities` and `PartUsage` (parent) components, the custom hook state gets associated to them. This means that only when the Activities or PartUsage panel get unmounted, does the custom hook's state gets cleared as well. Thus, we explicitly have to reset the errorMessages state so that we do not get the same old error messages upon re-opening the dialogs.

Depends on:
- https://github.com/cern-eam/eam-components/pull/132