### PR TITLE
[EAM-2744] Handle case of no report folder in EAM

### DIFF
--- a/src/ui/layout/menu/EamlightMenu.js
+++ b/src/ui/layout/menu/EamlightMenu.js
@@ -46,7 +46,7 @@ const getScreenHeaderFunction = (screens = {}) => ({ screenName, screen, updateS
 const EAM_REPORTS_MENU = "Lists & Reports"
 
 const generateReportMenuLinks = (menusMetaData) => (
-    menusMetaData.map((metadata) => {
+    menusMetaData?.map((metadata) => {
         if (['WEBD'].includes(metadata.classcode)) {
             const code = metadata.screencode;
             const link = '/grid?gridName=' + code;


### PR DESCRIPTION
Avoid the app being a blank page in case the reports folder hasn't yet been set up for a given user group.