### PR TITLE
[EAM-3126] Allow hidden top bar when inside iframe

### DIFF
--- a/src/ui/layout/ApplicationLayout.js
+++ b/src/ui/layout/ApplicationLayout.js
@@ -89,7 +89,7 @@ export default withStyles(styles)(function ApplicationLayout(props) {
     );
 
     const isInsideIframe = window.self !== window.top;
-    const isInsideAllowedURL = document.referrer.match(applicationData.EL_IFURL);
+    const isInsideAllowedURL = document.referrer.match('^' + applicationData.EL_IFURL);
     const showTopBar = !(isInsideAllowedURL && isInsideIframe);
 
     const loadAfterLogin = GridTools.getURLParameterByName("loadAfterLogin") === 'true';

--- a/src/ui/layout/ApplicationLayout.js
+++ b/src/ui/layout/ApplicationLayout.js
@@ -88,9 +88,9 @@ export default withStyles(styles)(function ApplicationLayout(props) {
         </div>
     );
 
-    const startsWithString = 'https://inforos-test.cern.ch';
     const isInsideIframe = window.self !== window.top;
-    const showTopBar = !(document.referrer.startsWith(startsWithString) && isInsideIframe);
+    const isInsideAllowedURL = document.referrer.match(applicationData.EL_IFURL);
+    const showTopBar = !(isInsideAllowedURL && isInsideIframe);
 
     const loadAfterLogin = GridTools.getURLParameterByName("loadAfterLogin") === 'true';
 


### PR DESCRIPTION
Now, the URLs for which the iframe can hide the top bar are not hardcoded; instead, they are fetched from EAM.