### PR TITLE
[EAM-3122] All custom tab grids displayed in the Position page

### DIFF
--- a/src/ui/components/entityregions/EntityRegions.js
+++ b/src/ui/components/entityregions/EntityRegions.js
@@ -119,7 +119,7 @@ const EntityRegions = (props) => {
                                     showMaximizeControls={region.maximizable}
                                     initiallyExpanded={expandedRegion === undefined || expandedRegion === region.id}
                                     {...region.RegionPanelProps}>
-                                    {region.render({ panelQueryParams: getRegionPanelQueryParams(region.id) })}
+                                    {region.render({ panelQueryParams: getRegionPanelQueryParams(region.id),  isMaximized: region.id === regionMaximized})}
                                 </RegionPanel>
                             ))
                         }

--- a/src/ui/pages/EntityTools.js
+++ b/src/ui/pages/EntityTools.js
@@ -1,6 +1,7 @@
 import set from "set-value";
 import queryString from "query-string";
 import formatfns from "date-fns/format";
+import { Link } from 'react-router-dom';
 import { parseISO } from "date-fns";
 import { processElementInfo } from "eam-components/dist/ui/components/inputs-ng/tools/input-tools";
 import { get } from "lodash";
@@ -275,3 +276,12 @@ export const prepareDataForFieldsValidator = (entity, screenLayout, layoutProper
 }
 
 export const isMultiOrg = process.env.REACT_APP_MULTI_ORG === 'TRUE';
+
+export const getCustomTabGridRenderers = (applicationData) => {
+    return {
+        'caseno': value => <a href={applicationData.EL_LOURL + value} target="_blank">{value}</a>,
+        'equipmentno': value => <Link to={{ pathname: `/equipment/${value}`}} target="_blank">{value}</Link>,
+        'workorderno': value => <Link to={{ pathname: `/workorder/${value}`}} target="_blank">{value}</Link>,
+        'partno': value => <Link to={{ pathname: `/part/${value}`}} target="_blank">{value}</Link>
+    }
+}

--- a/src/ui/pages/equipment/asset/Asset.js
+++ b/src/ui/pages/equipment/asset/Asset.js
@@ -19,7 +19,7 @@ import WSParts from '../../../../tools/WSParts';
 import EquipmentGraphIframe from '../../../components/iframes/EquipmentGraphIframe';
 import { isCernMode } from '../../../components/CERNMode';
 import { TAB_CODES } from '../../../components/entityregions/TabCodeMapping';
-import { getTabAvailability, getTabInitialVisibility, registerCustomField } from '../../EntityTools';
+import { getTabAvailability, getTabInitialVisibility, registerCustomField, getCustomTabGridRenderers} from '../../EntityTools';
 import NCRIframeContainer from '../../../components/iframes/NCRIframeContainer';
 import useEntity from "hooks/useEntity";
 import { isClosedEquipment, assetLayoutPropertiesMap } from '../EquipmentTools';
@@ -39,6 +39,10 @@ import AssignmentIndIcon from '@mui/icons-material/AssignmentInd';
 import HardwareIcon from '@mui/icons-material/Hardware';
 import { handleError } from 'actions/uiActions';
 import Variables from '../components/Variables';
+import GridOnIcon from '@mui/icons-material/GridOn';
+import EAMGridTab from 'eam-components/dist/ui/components/grids/eam/EAMGridTab.js';
+
+const customTabGridParamNames =  ["equipmentno", "obj_code", "main_eqp_code", "OBJ_CODE", "object", "puobject"];
 
 const Asset = () => {
     const [part, setPart] = useState(null);
@@ -102,6 +106,36 @@ const Asset = () => {
         WSEquipment.getEquipmentStatusValues(userData.eamAccount.userGroup, neweqp, statusCode)
             .then(response => setStatuses(response.body.data))
             .catch(console.error)
+    }
+
+    const getTabGridRegions = () => {
+        const customTabGridRenderers = getCustomTabGridRenderers(applicationData);
+        return Object.entries(assetLayout.customGridTabs).map(([tabId, tab], index) => {
+            return ({
+                id: tab.tabDescription.replaceAll(' ','').toUpperCase(),
+                label: tab.tabDescription,
+                isVisibleWhenNewEntity: true,
+                maximizable: true,
+                render: ({ isMaximized }) =>
+                    <EAMGridTab
+                        screenCode={screenCode}
+                        tabName={tabId}
+                        objectCode={equipment.code}
+                        paramNames= {customTabGridParamNames}
+                        customRenderers={customTabGridRenderers}
+                        showGrid={isMaximized}
+                        rowCount={100}
+                        gridContainerStyle={isMaximized ? { height: `${document.getElementById('entityContent').offsetHeight - 220}px`} : {}}
+                    >   
+                    </EAMGridTab>
+                ,
+                column: 2,
+                order: 30 + 5 * index,
+                summaryIcon: GridOnIcon,
+                ignore: !tab.tabAvailable,             
+                initialVisibility: tab.alwaysDisplayed    
+            });
+        })
     }
 
 
@@ -364,6 +398,7 @@ const Asset = () => {
                 ignore: !isCernMode || !getTabAvailability(tabs, TAB_CODES.EQUIPMENT_GRAPH_ASSETS),
                 initialVisibility: getTabInitialVisibility(tabs, TAB_CODES.EQUIPMENT_GRAPH_ASSETS)
             },
+            ...getTabGridRegions()
         ]
     }
 

--- a/src/ui/pages/equipment/location/Location.js
+++ b/src/ui/pages/equipment/location/Location.js
@@ -13,7 +13,7 @@ import EDMSDoclightIframeContainer from "../../../components/iframes/EDMSDocligh
 import NCRIframeContainer from '../../../components/iframes/NCRIframeContainer';
 import { ENTITY_TYPE } from "../../../components/Toolbar";
 import UserDefinedFields from "../../../components/userdefinedfields/UserDefinedFields";
-import { getTabAvailability, getTabInitialVisibility } from '../../EntityTools';
+import { getTabAvailability, getTabInitialVisibility, getCustomTabGridRenderers } from '../../EntityTools';
 import EquipmentHistory from "../components/EquipmentHistory.js";
 import EquipmentWorkOrders from "../components/EquipmentWorkOrders";
 import EamlightToolbarContainer from "./../../../components/EamlightToolbarContainer";
@@ -32,6 +32,10 @@ import FunctionsRoundedIcon from '@mui/icons-material/FunctionsRounded';
 import ListAltIcon from '@mui/icons-material/ListAlt';
 import ManageHistoryIcon from '@mui/icons-material/ManageHistory';
 import { locationLayoutPropertiesMap } from "../EquipmentTools";
+import GridOnIcon from '@mui/icons-material/GridOn';
+import EAMGridTab from 'eam-components/dist/ui/components/grids/eam/EAMGridTab.js';
+
+const customTabGridParamNames =  ["equipmentno", "obj_code", "main_eqp_code", "OBJ_CODE", "object", "puobject"];
 
 export default Location = (props) => {
 
@@ -75,6 +79,36 @@ export default Location = (props) => {
 
     function postCreate(location) {
         commentsComponent.current?.createCommentForNewEntity(location.code);
+    }
+
+    const getTabGridRegions = () => {
+        const customTabGridRenderers = getCustomTabGridRenderers(applicationData);
+        return Object.entries(locationLayout.customGridTabs).map(([tabId, tab], index) => {
+            return ({
+                id: tab.tabDescription.replaceAll(' ','').toUpperCase(),
+                label: tab.tabDescription,
+                isVisibleWhenNewEntity: true,
+                maximizable: true,
+                render: ({ isMaximized }) =>
+                    <EAMGridTab
+                        screenCode={screenCode}
+                        tabName={tabId}
+                        objectCode={equipment.code}
+                        paramNames= {customTabGridParamNames}
+                        customRenderers={customTabGridRenderers}
+                        showGrid={isMaximized}
+                        rowCount={100}
+                        gridContainerStyle={isMaximized ? { height: `${document.getElementById('entityContent').offsetHeight - 220}px`} : {}}
+                    >   
+                    </EAMGridTab>
+                ,
+                column: 2,
+                order: 30 + 5 * index,
+                summaryIcon: GridOnIcon,
+                ignore: !tab.tabAvailable,             
+                initialVisibility: tab.alwaysDisplayed    
+            });
+        })
     }
 
     const getRegions = () => {
@@ -297,6 +331,7 @@ export default Location = (props) => {
             //     ignore: !isCernMode,
             //     initialVisibility: false
             // },
+            ...getTabGridRegions()
         ]
 
     }

--- a/src/ui/pages/equipment/position/Position.js
+++ b/src/ui/pages/equipment/position/Position.js
@@ -115,7 +115,7 @@ const Position = () => {
                 label: tab.tabDescription,
                 isVisibleWhenNewEntity: true,
                 maximizable: true,
-                render: () =>
+                render: ({ isMaximized }) =>
                     <EAMGridTab
                         screenCode={screenCode}
                         tabName={tabId}
@@ -123,6 +123,7 @@ const Position = () => {
                         customRenderers={customRenderers(applicationData)}
                         showGrid={showGrid[tabId]}
                         rowCount={100}
+                        gridContainerStyle={{ height: isMaximized ? '65vh' : '300px'}}
                     >   
                     </EAMGridTab>
                 ,

--- a/src/ui/pages/equipment/position/Position.js
+++ b/src/ui/pages/equipment/position/Position.js
@@ -43,7 +43,7 @@ import Variables from '../components/Variables.js';
 import EAMGridTab from 'eam-components/dist/ui/components/grids/eam/EAMGridTab.js';
 
 
-const customRenderers = (applicationData) => {
+const getCustomRenderers = (applicationData) => {
     return {
         'caseno': value => <a href={applicationData.EL_LOURL + value} target="_blank">{value}</a>,
         'equipmentno': value => <Link to={{ pathname: `/equipment/${value}`}} target="_blank">{value}</Link>,
@@ -103,12 +103,13 @@ const Position = () => {
 
         const toggleGrid = (tabId) => {
             setShowGrid(prevState => ({
-              ...prevState, // Mantenemos el estado anterior
-              [tabId]: !prevState[tabId] // Cambiamos el valor de la propiedad específica
+              ...prevState,
+              [tabId]: !prevState[tabId]
             }));
           };
     
     const getTabGridRegions = () => {
+        const customRenderers = getCustomRenderers(applicationData);
         return Object.entries(positionLayout.customGridTabs).map(([tabId, tab], index) => {
             return ({
                 id: tab.tabDescription.replaceAll(' ','').toUpperCase(),
@@ -120,7 +121,7 @@ const Position = () => {
                         screenCode={screenCode}
                         tabName={tabId}
                         objectCode={equipment.code}
-                        customRenderers={customRenderers(applicationData)}
+                        customRenderers={customRenderers}
                         showGrid={showGrid[tabId]}
                         rowCount={100}
                         gridContainerStyle={{ height: isMaximized ? '65vh' : '300px'}}

--- a/src/ui/pages/equipment/system/System.js
+++ b/src/ui/pages/equipment/system/System.js
@@ -18,7 +18,7 @@ import EntityRegions from "../../../components/entityregions/EntityRegions";
 import EquipmentGraphIframe from '../../../components/iframes/EquipmentGraphIframe';
 import { isCernMode } from '../../../components/CERNMode';
 import { TAB_CODES } from '../../../components/entityregions/TabCodeMapping';
-import { getTabAvailability, getTabInitialVisibility } from '../../EntityTools';
+import { getTabAvailability, getTabInitialVisibility, getCustomTabGridRenderers } from '../../EntityTools';
 import useEntity from "hooks/useEntity";
 import { isClosedEquipment, systemLayoutPropertiesMap } from '../EquipmentTools.js';
 import ClearAllIcon from '@mui/icons-material/ClearAll';
@@ -34,6 +34,10 @@ import AccountTreeRoundedIcon from '@mui/icons-material/AccountTreeRounded';
 import ManageHistoryIcon from '@mui/icons-material/ManageHistory';
 import AssignmentIndIcon from '@mui/icons-material/AssignmentInd';
 import Variables from '../components/Variables.js';
+import GridOnIcon from '@mui/icons-material/GridOn';
+import EAMGridTab from 'eam-components/dist/ui/components/grids/eam/EAMGridTab.js';
+
+const customTabGridParamNames =  ["equipmentno", "obj_code", "main_eqp_code", "OBJ_CODE", "object", "puobject"];
 
 const System = () => {
     const [statuses, setStatuses] = useState([]);
@@ -89,6 +93,36 @@ const System = () => {
             return 'A';
         }
         return 'X';
+    }
+
+    const getTabGridRegions = () => {
+        const customTabGridRenderers = getCustomTabGridRenderers(applicationData);
+        return Object.entries(systemLayout.customGridTabs).map(([tabId, tab], index) => {
+            return ({
+                id: tab.tabDescription.replaceAll(' ','').toUpperCase(),
+                label: tab.tabDescription,
+                isVisibleWhenNewEntity: true,
+                maximizable: true,
+                render: ({ isMaximized }) =>
+                    <EAMGridTab
+                        screenCode={screenCode}
+                        tabName={tabId}
+                        objectCode={equipment.code}
+                        paramNames= {customTabGridParamNames}
+                        customRenderers={customTabGridRenderers}
+                        showGrid={isMaximized}
+                        rowCount={100}
+                        gridContainerStyle={isMaximized ? { height: `${document.getElementById('entityContent').offsetHeight - 220}px`} : {}}
+                    >   
+                    </EAMGridTab>
+                ,
+                column: 2,
+                order: 30 + 5 * index,
+                summaryIcon: GridOnIcon,
+                ignore: !tab.tabAvailable,             
+                initialVisibility: tab.alwaysDisplayed    
+            });
+        })
     }
 
     const getRegions = () => {
@@ -319,6 +353,7 @@ const System = () => {
                 ignore: !isCernMode || !getTabAvailability(tabs, TAB_CODES.EQUIPMENT_GRAPH_SYSTEMS),
                 initialVisibility: getTabInitialVisibility(tabs, TAB_CODES.EQUIPMENT_GRAPH_SYSTEMS)
             },
+            ...getTabGridRegions()
         ]
     }
 

--- a/src/ui/pages/part/Part.js
+++ b/src/ui/pages/part/Part.js
@@ -15,7 +15,7 @@ import EDMSDoclightIframeContainer from "../../components/iframes/EDMSDoclightIf
 import {ENTITY_TYPE} from '../../components/Toolbar';
 import EntityRegions from "../../components/entityregions/EntityRegions";
 import { TAB_CODES } from '../../components/entityregions/TabCodeMapping';
-import { getTabAvailability, getTabInitialVisibility } from '../EntityTools';
+import { getTabAvailability, getTabInitialVisibility, getCustomTabGridRenderers } from '../EntityTools';
 import useEntity from "hooks/useEntity";
 
 import { AssetIcon, PartIcon } from 'eam-components/dist/ui/components/icons'
@@ -26,6 +26,10 @@ import DriveFileRenameOutlineIcon from '@mui/icons-material/DriveFileRenameOutli
 import ListAltIcon from '@mui/icons-material/ListAlt';
 import AssignmentIndIcon from '@mui/icons-material/AssignmentInd';
 import PlaceIcon from '@mui/icons-material/Place';
+import GridOnIcon from '@mui/icons-material/GridOn';
+import EAMGridTab from 'eam-components/dist/ui/components/grids/eam/EAMGridTab.js';
+
+const customTabGridParamNames =  ["equipmentno", "obj_code", "part", "PAR_CODE", "par_code", "OBJ_CODE", "object", "puobject"];
 
 const Part = () => {
     const {screenLayout: partLayout, entity: part, loading, readOnly, isModified,
@@ -64,6 +68,36 @@ const Part = () => {
 
     function postUpdate() {
         commentsComponent.current.createCommentForNewEntity();
+    }
+
+    const getTabGridRegions = () => {
+        const customTabGridRenderers = getCustomTabGridRenderers(applicationData);
+        return Object.entries(partLayout.customGridTabs).map(([tabId, tab], index) => {
+            return ({
+                id: tab.tabDescription.replaceAll(' ','').toUpperCase(),
+                label: tab.tabDescription,
+                isVisibleWhenNewEntity: true,
+                maximizable: true,
+                render: ({ isMaximized }) =>
+                    <EAMGridTab
+                        screenCode={screenCode}
+                        tabName={tabId}
+                        objectCode={part.code}
+                        paramNames= {customTabGridParamNames}
+                        customRenderers={customTabGridRenderers}
+                        showGrid={isMaximized}
+                        rowCount={100}
+                        gridContainerStyle={isMaximized ? { height: `${document.getElementById('entityContent').offsetHeight - 220}px`} : {}}
+                    >   
+                    </EAMGridTab>
+                ,
+                column: 2,
+                order: 30 + 5 * index,
+                summaryIcon: GridOnIcon,
+                ignore: !tab.tabAvailable,             
+                initialVisibility: tab.alwaysDisplayed    
+            });
+        })
     }
 
     const getRegions = () => {
@@ -221,6 +255,7 @@ const Part = () => {
                 ignore: partLayout.fields.block_6.attribute === 'H',
                 initialVisibility: getTabInitialVisibility(tabs, TAB_CODES.RECORD_VIEW)
             },
+            ...getTabGridRegions()
         ]
     }
 

--- a/src/ui/pages/work/Workorder.js
+++ b/src/ui/pages/work/Workorder.js
@@ -27,7 +27,7 @@ import TuneIcon from '@mui/icons-material/Tune';
 import {IconSlash} from 'eam-components/dist/ui/components/icons/index';
 import { isCernMode } from '../../components/CERNMode';
 import { TAB_CODES } from '../../components/entityregions/TabCodeMapping';
-import { getTabAvailability, getTabInitialVisibility, registerCustomField } from '../EntityTools';
+import { getTabAvailability, getTabInitialVisibility, registerCustomField, getCustomTabGridRenderers } from '../EntityTools';
 import WSParts from '../../../tools/WSParts';
 import WSWorkorders from '../../../tools/WSWorkorders';
 import useEntity from "hooks/useEntity";
@@ -53,6 +53,8 @@ import { PartIcon } from 'eam-components/dist/ui/components/icons';
 import FunctionsRoundedIcon from '@mui/icons-material/FunctionsRounded';
 import HardwareIcon from '@mui/icons-material/Hardware';
 import PrecisionManufacturingIcon from '@mui/icons-material/PrecisionManufacturing';
+import GridOnIcon from '@mui/icons-material/GridOn';
+import EAMGridTab from 'eam-components/dist/ui/components/grids/eam/EAMGridTab.js';
 
 const getEquipmentStandardWOMaxStep = async (eqCode, swoCode) => {
     if (!eqCode || !swoCode) {
@@ -61,6 +63,8 @@ const getEquipmentStandardWOMaxStep = async (eqCode, swoCode) => {
     const response = await WSWorkorder.getEquipmentStandardWOMaxStep(eqCode, swoCode);
     return response.body.data;
 }
+
+const customTabGridParamNames =  ["evt_code", "EVENT", "WO_CODE"];
 
 const Workorder = () => {
     const history = useHistory();
@@ -177,6 +181,36 @@ const Workorder = () => {
             .then(response => setWorkOrder( oldWorkOrder => assignStandardWorkOrderValues(oldWorkOrder, response.body.data)))
             .catch(console.error);
         }
+    }
+
+    const getTabGridRegions = () => {
+        const customTabGridRenderers = getCustomTabGridRenderers(applicationData);
+        return Object.entries(workOrderLayout.customGridTabs).map(([tabId, tab], index) => {
+            return ({
+                id: tab.tabDescription.replaceAll(' ','').toUpperCase(),
+                label: tab.tabDescription,
+                isVisibleWhenNewEntity: true,
+                maximizable: true,
+                render: ({ isMaximized }) =>
+                    <EAMGridTab
+                        screenCode={screenCode}
+                        tabName={tabId}
+                        objectCode={workorder.number}
+                        paramNames= {customTabGridParamNames}
+                        customRenderers={customTabGridRenderers}
+                        showGrid={isMaximized}
+                        rowCount={100}
+                        gridContainerStyle={isMaximized ? { height: `${document.getElementById('entityContent').offsetHeight - 220}px`} : {}}
+                    >   
+                    </EAMGridTab>
+                ,
+                column: 2,
+                order: 30 + 5 * index,
+                summaryIcon: GridOnIcon,
+                ignore: !tab.tabAvailable,             
+                initialVisibility: tab.alwaysDisplayed    
+            });
+        })
     }
 
     const getRegions = () => {
@@ -539,6 +573,7 @@ const Workorder = () => {
                 ignore: !getTabAvailability(tabs, TAB_CODES.RECORD_VIEW),
                 initialVisibility: getTabInitialVisibility(tabs, TAB_CODES.RECORD_VIEW)
             },
+            ...getTabGridRegions()
         ];
     }
 


### PR DESCRIPTION
**Limitations:**

- The tab grids displayed are limited to those following the pattern: parentScreenCode_X* (e.g., OSOBJ_XAC). Therefore, custom tab grids must adhere to this naming convention to be displayed. EAM enforces this naming convention. Other screens should not adopt this structure.
- Links are displayed only for fields with the aliases: caseno, equipmentno, workorderno, partno.
- Custom tab grids are exclusively visible on the Position page. However, they can be added to other equipment pages, which should be easy.
- The param must be one of these: "position", "obj_code", "main_eqp_code", "OBJ_CODE", "object". This can be expanded. Determined by eam-components.