### PR TITLE
feat: EAM-4185 add or hide panel for outside cern user

### DIFF
--- a/src/state/useLayoutStore.js
+++ b/src/state/useLayoutStore.js
@@ -1,14 +1,32 @@
-import { create } from 'zustand';
+import { create } from "zustand";
 import WS from "../tools/WS";
 
 const useLayoutStore = create((set) => ({
-  screenLayout: {}, 
+  screenLayout: {},
   screenLayoutFetchError: false, // Add a boolean property to track fetch errors
-  
-  fetchScreenLayout: async (userGroup, entity, parentScreen, screen, tabs, screenProperty) => {
+
+  fetchScreenLayout: async (
+    userGroup,
+    entity,
+    parentScreen,
+    screen,
+    tabs,
+    screenProperty
+  ) => {
     try {
-      const newScreenLayout = await WS.getScreenLayout(userGroup, entity, parentScreen, screen, tabs)
-        .then((result) => result.body.data);
+      let newScreenLayout = await WS.getScreenLayout(
+        userGroup,
+        entity,
+        parentScreen,
+        screen,
+        tabs
+      ).then((result) => result.body.data);
+      if (screen === "OSOBJA") {
+        delete newScreenLayout.customGridTabs.XDP;
+      } else if (screen === "OSOBJP") {
+        delete newScreenLayout.customGridTabs.XPI;
+        delete newScreenLayout.customGridTabs.XPM;
+      }
 
       set((state) => ({
         screenLayout: {

--- a/src/ui/components/statusrow/StatusRow.jsx
+++ b/src/ui/components/statusrow/StatusRow.jsx
@@ -14,14 +14,14 @@ import {
 import { isCernMode } from "../CERNMode";
 import GridWS from "eam-components/dist/ui/components/eamgrid/lib/GridWS";
 
-async function doEquipmentGridRequest(equipmentCode, screenCode, tabName) {
+async function doEquipmentGridRequest(equipmentCode, screenCode, tabName, organization) {
   if (equipmentCode && screenCode) {
     const gridRequest = {
       rowCount: 1,
       params: {
         //equipmentno: equipmentCode,
         "parameter.object": equipmentCode,
-        "parameter.objorganization": "*",
+        "parameter.objorganization": organization ?? "*",
       },
       gridName: screenCode + "_" + tabName,
       userFunctionName: screenCode,
@@ -140,7 +140,7 @@ const StatusRow = (props) => {
   const generateCells = (entity, entityType, screenCode) => {
     const [hasHazards, setHasHazards] = useState(false);
     useEffect(() => {
-      const safetyData = doEquipmentGridRequest(entity.code, screenCode, "ESF");
+      const safetyData = doEquipmentGridRequest(entity.code, screenCode, "ESF", entity.organization);
       safetyData.then((data) => setHasHazards(data.records !== "0"));
     }, [entity.code]);
 

--- a/src/ui/pages/equipment/asset/Asset.jsx
+++ b/src/ui/pages/equipment/asset/Asset.jsx
@@ -97,7 +97,6 @@ const Asset = () => {
     layoutProperty: "assetLayout",
     layoutPropertiesMap: assetLayoutPropertiesMap,
   });
-
   useEffect(() => {
     // Part input is cleared
     if (equipment?.partCode === "") {
@@ -232,7 +231,7 @@ const Asset = () => {
         column: 1,
         order: 25,
         summaryIcon: ManageHistoryIcon,
-        ignore: !isCernMode || !getTabAvailability(tabs, TAB_CODES.RECORD_VIEW),
+        ignore: !getTabAvailability(tabs, TAB_CODES.RECORD_VIEW),
         initialVisibility: getTabInitialVisibility(tabs, TAB_CODES.RECORD_VIEW),
       },
       {
@@ -245,7 +244,7 @@ const Asset = () => {
             gridName={"OSOBJA_ESF"}
             objectCode={equipment.code}
             additionalParams={Object.fromEntries([
-              ["parameter.objorganization", "*"],
+              ["parameter.objorganization", equipment.organization ?? "*"],
               ["parameter.object", equipment.code],
             ])}
             paramNames={["equipmentno"]}
@@ -305,7 +304,7 @@ const Asset = () => {
         column: 2,
         order: 7,
         summaryIcon: BookmarkBorderRoundedIcon,
-        ignore: !isCernMode 
+        ignore: !isCernMode
       },
       {
         id: "COMMENTS",
@@ -405,7 +404,7 @@ const Asset = () => {
         ignore: !isCernMode || !getTabAvailability(tabs, TAB_CODES.EQUIPMENT_GRAPH_ASSETS),
         initialVisibility: getTabInitialVisibility(tabs, TAB_CODES.EQUIPMENT_GRAPH_ASSETS),
       },
-      getPartsAssociated(
+     getPartsAssociated(
         equipment.code,
         equipment.organization,
         !getTabAvailability(tabs, TAB_CODES.PARTS_ASSOCIATED),

--- a/src/ui/pages/equipment/components/EquipmentWorkOrders.jsx
+++ b/src/ui/pages/equipment/components/EquipmentWorkOrders.jsx
@@ -46,7 +46,8 @@ const WO_FILTERS = {
 const LOCAL_STORAGE_FILTER_KEY = 'filters:workorders';
 
 function EquipmentWorkOrders(props) {
-    const { defaultFilter, equipmentcode, equipmenttype } = props;
+    const { defaultFilter: initialFilter, equipmentcode, equipmenttype } = props;
+    const defaultFilter = initialFilter ?? WO_FILTER_TYPES.THIS;
 
     let [events, setEvents] = useState([]);
     let [workorders, setWorkorders] = useState([]);
@@ -126,7 +127,7 @@ function EquipmentWorkOrders(props) {
                 }
                 activeFilter={workOrderFilter}
                 />
-                
+
             {workOrderFilter === WO_FILTER_TYPES.MTF ?
                 <EquipmentMTFWorkOrders equipmentcode={equipmentcode} />
                 :

--- a/src/ui/pages/equipment/position/Position.jsx
+++ b/src/ui/pages/equipment/position/Position.jsx
@@ -229,7 +229,7 @@ const Position = () => {
         column: 1,
         order: 25,
         summaryIcon: ManageHistoryIcon,
-        ignore: !getTabAvailability(tabs, TAB_CODES.WORKORDERS),
+        ignore:  !isCernMode || !getTabAvailability(tabs, TAB_CODES.WORKORDERS),
         initialVisibility: getTabInitialVisibility(tabs, TAB_CODES.WORKORDERS),
       },
       getPartsAssociated(


### PR DESCRIPTION
5. Asset (example CONTKR-001) 

Work Orders: Filter All, Open not working, This Equip should be default. **ok**
Creation Date is missing: **Ok**
No History block -> **Panel has been added**
Safety **ok**
Dependencies are empty -> **Panel has been removed because not present in the current EAM light**
 

6. Position (example 338.118) 

Work Orders: Filter All, Open not working, This Equip should be default.  **ok**
Creation Date is missing:  **OK**
Equipment in structure, PM Schedules in Structure are empty -> **Panels has been removed because not present in the current EAM light**
(Strukture custom tab grid nicely displayed!) 
History empty -> **Panel has been removed**