### PR TITLE
Add fallback NCRs for WO Equipment

### DIFF
--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -3,3 +3,16 @@ export const isLocalAdministrator = (userData) =>
     userData.eamAccount &&
     userData.eamAccount.userDefinedFields &&
     userData.eamAccount.userDefinedFields.udfchkbox01;
+
+export const isValidHttpUrl = (str) => {
+    const pattern = new RegExp(
+        '^(https?:\\/\\/)?' + // protocol
+        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
+        '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
+        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
+        '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
+        '(\\#[-a-z\\d_]*)?$', // fragment locator
+        'i'
+    );
+    return pattern.test(str);
+}

--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -3,16 +3,3 @@ export const isLocalAdministrator = (userData) =>
     userData.eamAccount &&
     userData.eamAccount.userDefinedFields &&
     userData.eamAccount.userDefinedFields.udfchkbox01;
-
-export const isValidHttpUrl = (str) => {
-    const pattern = new RegExp(
-        '^(https?:\\/\\/)?' + // protocol
-        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
-        '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
-        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-        '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
-        '(\\#[-a-z\\d_]*)?$', // fragment locator
-        'i'
-    );
-    return pattern.test(str);
-}

--- a/src/ui/components/iframes/NCRIframeContainer.jsx
+++ b/src/ui/components/iframes/NCRIframeContainer.jsx
@@ -1,5 +1,7 @@
+/* eslint-disable react/prop-types */
 import ComponentIframe from './ComponentIframe';
-import { withCernMode } from '../CERNMode';
+import AssetNCRs from '../../pages/equipment/components/EquipmentNCRs';
+
 
 const NCRIframeContainer = (props) => {
     const defaultProps = {
@@ -12,7 +14,23 @@ const NCRIframeContainer = (props) => {
         ...props // Allow additional props to override defaults
     };
 
-    return <ComponentIframe {...defaultProps} />;
+    function isValidHttpUrl(string) {
+        let url;
+        try {
+            url = new URL(string);
+        } catch (_) {
+            return false;  
+        }
+        return url.protocol === "http:" || url.protocol === "https:";
+    }
+
+    return (
+        isValidHttpUrl(props?.url) ? 
+            <ComponentIframe {...defaultProps} />
+        : (
+            <AssetNCRs equipment={props.equipmentCode} />
+        )
+    )
 };
 
-export default withCernMode(NCRIframeContainer);
+export default NCRIframeContainer;

--- a/src/ui/components/iframes/NCRIframeContainer.jsx
+++ b/src/ui/components/iframes/NCRIframeContainer.jsx
@@ -1,7 +1,5 @@
-/* eslint-disable react/prop-types */
 import ComponentIframe from './ComponentIframe';
-import AssetNCRs from '../../pages/equipment/components/EquipmentNCRs';
-
+import { withCernMode } from '../CERNMode';
 
 const NCRIframeContainer = (props) => {
     const defaultProps = {
@@ -14,23 +12,7 @@ const NCRIframeContainer = (props) => {
         ...props // Allow additional props to override defaults
     };
 
-    function isValidHttpUrl(string) {
-        let url;
-        try {
-            url = new URL(string);
-        } catch (_) {
-            return false;  
-        }
-        return url.protocol === "http:" || url.protocol === "https:";
-    }
-
-    return (
-        isValidHttpUrl(props?.url) ? 
-            <ComponentIframe {...defaultProps} />
-        : (
-            <AssetNCRs equipment={props.equipmentCode} />
-        )
-    )
+    return <ComponentIframe {...defaultProps} />;
 };
 
-export default NCRIframeContainer;
+export default withCernMode(NCRIframeContainer);

--- a/src/ui/pages/work/Workorder.jsx
+++ b/src/ui/pages/work/Workorder.jsx
@@ -58,7 +58,8 @@ import HardwareIcon from "@mui/icons-material/Hardware";
 import PrecisionManufacturingIcon from "@mui/icons-material/PrecisionManufacturing";
 import EamlightToolbar from "../../components/EamlightToolbar";
 import useWorkOrderStore from "../../../state/useWorkOrderStore";
-import { isLocalAdministrator } from "../../../state/utils";
+import { isLocalAdministrator, isValidHttpUrl } from "../../../state/utils";
+import AssetNCRs from '../../pages/equipment/components/EquipmentNCRs';
 
 const getEquipmentStandardWOMaxStep = async (eqCode, swoCode) => {
   if (!eqCode || !swoCode) {
@@ -341,8 +342,9 @@ const Workorder = () => {
         label: "NCRs",
         isVisibleWhenNewEntity: false,
         maximizable: true,
-        render: () => (
-            <NCRIframeContainer
+        render: () => ( 
+          isValidHttpUrl(`${applicationData.EL_TBURL}/ncr`) 
+            ? <NCRIframeContainer
                 objectType="J"
                 objectID={workorder.number}
                 equipmentCode={workorder.equipmentCode}
@@ -350,6 +352,7 @@ const Workorder = () => {
                 url={`${applicationData.EL_TBURL}/ncr`}
                 edmsDocListLink={applicationData.EL_EDMSL}
             />
+            : <AssetNCRs equipment={workorder.equipmentCode} />
         ),
         RegionPanelProps: {
           detailsStyle: { padding: 0 },

--- a/src/ui/pages/work/Workorder.jsx
+++ b/src/ui/pages/work/Workorder.jsx
@@ -345,6 +345,7 @@ const Workorder = () => {
             <NCRIframeContainer
                 objectType="J"
                 objectID={workorder.number}
+                equipmentCode={workorder.equipmentCode}
                 mode="NCR"
                 url={`${applicationData.EL_TBURL}/ncr`}
                 edmsDocListLink={applicationData.EL_EDMSL}

--- a/src/ui/pages/work/Workorder.jsx
+++ b/src/ui/pages/work/Workorder.jsx
@@ -57,7 +57,7 @@ import HardwareIcon from "@mui/icons-material/Hardware";
 import PrecisionManufacturingIcon from "@mui/icons-material/PrecisionManufacturing";
 import EamlightToolbar from "../../components/EamlightToolbar";
 import useWorkOrderStore from "../../../state/useWorkOrderStore";
-import { isLocalAdministrator, isValidHttpUrl } from "../../../state/utils";
+import { isLocalAdministrator } from "../../../state/utils";
 import AssetNCRs from '../../pages/equipment/components/EquipmentNCRs';
 
 const getEquipmentStandardWOMaxStep = async (eqCode, swoCode) => {
@@ -342,11 +342,10 @@ const Workorder = () => {
         isVisibleWhenNewEntity: false,
         maximizable: true,
         render: () => ( 
-          isValidHttpUrl(`${applicationData.EL_TBURL}/ncr`) 
+          applicationData.EL_TBURL 
             ? <NCRIframeContainer
                 objectType="J"
                 objectID={workorder.number}
-                equipmentCode={workorder.equipmentCode}
                 mode="NCR"
                 url={`${applicationData.EL_TBURL}/ncr`}
                 edmsDocListLink={applicationData.EL_EDMSL}

--- a/src/ui/pages/work/Workorder.jsx
+++ b/src/ui/pages/work/Workorder.jsx
@@ -14,7 +14,6 @@ import Activities from "./activities/Activities";
 import AdditionalCosts from "./additionalcosts/AdditionalCosts";
 import WorkorderChildren from "./childrenwo/WorkorderChildren";
 import MeterReadingWO from "./meter/MeterReadingWO";
-import WorkorderMultiequipment from "./multiequipmentwo/WorkorderMultiequipment";
 import PartUsage from "./partusage/PartUsage";
 import WorkorderClosingCodes from "./WorkorderClosingCodes";
 import WorkorderGeneral from "./WorkorderGeneral";
@@ -553,19 +552,6 @@ const Workorder = () => {
         summaryIcon: SpeedIcon,
         ignore: !getTabAvailability(tabs, TAB_CODES.METER_READINGS),
         initialVisibility: getTabInitialVisibility(tabs, TAB_CODES.METER_READINGS),
-      },
-      {
-        id: "MULTIPLEEQUIPMENT",
-        label: "Equipment",
-        isVisibleWhenNewEntity: false,
-        customVisibility: () => isRegionAvailable("MEC", commonProps.workOrderLayout),
-        maximizable: false,
-        render: () => <WorkorderMultiequipment workorder={workorder.number} setEquipmentMEC={setEquipmentMEC} />,
-        column: 2,
-        order: 13,
-        summaryIcon: PrecisionManufacturingIcon,
-        ignore: !getTabAvailability(tabs, TAB_CODES.EQUIPMENT_TAB_WO_SCREEN),
-        initialVisibility: getTabInitialVisibility(tabs, TAB_CODES.EQUIPMENT_TAB_WO_SCREEN),
       },
       {
         id: "USERDEFINEDFIELDS",


### PR DESCRIPTION
src/ui/pages/equipment/components/EquipmentNCRs.jsx already contained a standalone component to fetch NCRs using equipment code. It is now used as a fallback if the URL passed to src/ui/components/iframes/NCRIframeContainer.jsx is invalid